### PR TITLE
Improve monitoring db handling

### DIFF
--- a/quantnet_controller/common/request_translator.py
+++ b/quantnet_controller/common/request_translator.py
@@ -104,7 +104,7 @@ def _validate_agent_requirements(exp_def, available_nodes, heartbeat_timeout=Non
         raise ValueError(error_msg)
 
     logger.debug(f"Agent validation passed. Required: {required_types}, Available: {available_types}")
-    return is_valid, required_types, available_types, missing_types
+    return reachable_nodes
 
 
 def match_agent_to_exp(exp_def, path, validate=True):
@@ -125,20 +125,23 @@ def match_agent_to_exp(exp_def, path, validate=True):
     """
     # Handle both Path objects and lists of node IDs
     if hasattr(path, "hops"):
-        nodes = [x for x in path.hops if x is not None and x.systemSettings.type != "OpticalSwitch"] if path.hops else []
+        nodes = (
+            [x for x in path.hops if x is not None and x.systemSettings.type != "OpticalSwitch"]
+            if path.hops else []
+        )
     else:
         # If path is already a list (from DB), reconstruct nodes
         nodes = path if isinstance(path, list) else []
 
-    # Validate requirements if requested
+    # Validate requirements if requested; use filtered reachable_nodes for matching
     if validate:
-        _validate_agent_requirements(exp_def, nodes)
+        nodes = _validate_agent_requirements(exp_def, nodes)
 
     # Perform matching with non-mutating approach
     mapping = []
-    nodes_copy = list(nodes)  # Create copy to avoid mutation
+    nodes_copy = list(nodes)
     exp_nodes = [x.node_type for x in exp_def.agent_sequences]
-    
+
     for node_type in exp_nodes:
         for i in range(len(nodes_copy)):
             node_id = nodes_copy[i] if isinstance(nodes_copy[i], str) else nodes_copy[i].systemSettings.ID
@@ -266,8 +269,8 @@ class RequestTranslator:
         :type parameters['exp_name']: str
         :param parameters['path']: Path object or list of node IDs.
         :type parameters['path']: Any
-        :param parameters['params']: Experiment-specific parameters.
-        :type parameters['params']: dict | list | Any
+        :param parameters['exp_params']: Experiment-specific parameters.
+        :type parameters['exp_params']: dict | list | Any
         :param parameters['payload_data']: Optional additional payload data.
         :type parameters['payload_data']: Any | None
 

--- a/quantnet_controller/core/__init__.py
+++ b/quantnet_controller/core/__init__.py
@@ -1,9 +1,10 @@
 """
 """
-from quantnet_controller.core.abstractdatabase import AbstractDatabase, DBmodel
+from quantnet_controller.core.abstractdatabase import AbstractDatabase, AsyncAbstractDatabase, DBmodel
 from quantnet_controller.core.managers import ResourceManager, ControllerContextManager
 
 __all__ = ['AbstractDatabase',
+           'AsyncAbstractDatabase',
            'DBmodel',
            'ResourceManager',
            'ControllerContextManager']

--- a/quantnet_controller/core/abstractdatabase.py
+++ b/quantnet_controller/core/abstractdatabase.py
@@ -1,4 +1,5 @@
 from quantnet_controller.db.broker import broker as db_broker, Broker
+from quantnet_controller.db.async_broker import async_broker, AsyncBroker
 
 
 class DBmodel():
@@ -10,6 +11,7 @@ class DBmodel():
     PingPong = "PingPong"
     Blob = "Blob"
 
+# TODO: Make Async version of AbstractDatabase (AsyncAbstractDatabase) to support async database operations
 
 class AbstractDatabase():
     """
@@ -228,3 +230,96 @@ class AbstractDatabase():
 
         """
         return broker.exist(model, id, **kwargs)
+
+
+class AsyncAbstractDatabase:
+    """
+    Async version of AbstractDatabase.
+
+    Consumers use `AsyncAbstractDatabase().handler(DBmodel.X)` to get an
+    `AsyncDBModel` proxy whose methods are all `async def`. The underlying
+    DB calls use pymongo's native async API (AsyncMongoClient) with no
+    thread-pool wrapping.
+
+    The sync `AbstractDatabase` is unchanged — sync callers are unaffected.
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    class AsyncDBModel:
+        def __init__(self, db, model):
+            self._db = db
+            self._model = model
+
+        async def add(self, data, **kwargs) -> dict:
+            return await self._db.add(self._model, data, **kwargs)
+
+        async def get(self, id, **kwargs) -> dict | None:
+            return await self._db.get(self._model, id, **kwargs)
+
+        async def find(self, **kwargs) -> list:
+            return await self._db.find(self._model, **kwargs)
+
+        async def update(self, id, key, value, **kwargs) -> bool:
+            return await self._db.update(self._model, id, key, value, **kwargs)
+
+        async def upsert(self, id, *args, **kwargs) -> bool:
+            return await self._db.upsert(self._model, id, *args, **kwargs)
+
+        async def delete(self, id, **kwargs) -> int:
+            return await self._db.delete(self._model, id, **kwargs)
+
+        async def exist(self, id, **kwargs) -> bool:
+            return await self._db.exist(self._model, id, **kwargs)
+
+        async def drop(self, **kwargs) -> None:
+            return await self._db.drop(self._model, **kwargs)
+
+    def handler(self, model=DBmodel.Blob):
+        """Return an async table/collection handler."""
+        return AsyncAbstractDatabase.AsyncDBModel(self, model)
+
+    @staticmethod
+    @async_broker
+    async def add(model, data, broker: AsyncBroker, **kwargs):
+        return await broker.add(model, data, **kwargs)
+
+    @staticmethod
+    @async_broker
+    async def get(model, id, broker: AsyncBroker, **kwargs):
+        return await broker.get(model, id, **kwargs)
+
+    @staticmethod
+    @async_broker
+    async def find(model, broker: AsyncBroker, **kwargs) -> list:
+        return await broker.find(model, **kwargs)
+
+    @staticmethod
+    @async_broker
+    async def update(model, id, key, value, broker: AsyncBroker, **kwargs):
+        return await broker.update(model, id, key, value, **kwargs)
+
+    @staticmethod
+    @async_broker
+    async def upsert(model, id, *args, broker: AsyncBroker, **kwargs):
+        return await broker.upsert(model, id, *args, **kwargs)
+
+    @staticmethod
+    @async_broker
+    async def delete(model, id, broker: AsyncBroker, **kwargs):
+        return await broker.delete(model, id, **kwargs)
+
+    @staticmethod
+    @async_broker
+    async def exist(model, id, broker: AsyncBroker, **kwargs):
+        return await broker.exist(model, id, **kwargs)
+
+    @staticmethod
+    @async_broker
+    async def drop(model, broker: AsyncBroker, **kwargs):
+        return await broker.drop(model, **kwargs)

--- a/quantnet_controller/core/abstractdatabase.py
+++ b/quantnet_controller/core/abstractdatabase.py
@@ -5,6 +5,7 @@ class DBmodel():
     Node = "Node"
     Request = "Request"
     Monitor = "Monitor"
+    MonitorState = "MonitorState"
     Calibration = "Calibration"
     PingPong = "PingPong"
     Blob = "Blob"

--- a/quantnet_controller/core/managers.py
+++ b/quantnet_controller/core/managers.py
@@ -2,7 +2,6 @@
 Resource Manager
 """
 
-import asyncio
 import json
 import logging
 import types
@@ -11,7 +10,7 @@ from networkx import node_link_data
 import quantnet_mq.schema.models as models
 from quantnet_mq import EventType
 from quantnet_controller.common.config import Config
-from quantnet_controller.core import AbstractDatabase as DB, DBmodel
+from quantnet_controller.core import AbstractDatabase as DB, AsyncAbstractDatabase as AsyncDB, DBmodel
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +18,9 @@ logger = logging.getLogger(__name__)
 class ResourceManager:
     def __init__(self, rtype="nodes", key="agentId", **kwargs):
         self._topo = None
-        self._node_db = DB().handler(DBmodel.Node)
-        self._request_db = DB().handler(DBmodel.Request)
+        self._node_db = DB().handler(DBmodel.Node)          # sync — used by find_nodes, get_nodes
+        self._request_db = DB().handler(DBmodel.Request)    # sync — used by _handle_request
+        self._async_node_db = AsyncDB().handler(DBmodel.Node)  # async — used by handle_register
         self._is_topo_updated = False
         self._is_topo_full = False
 
@@ -54,8 +54,7 @@ class ResourceManager:
         """Capture all requests to the controller"""
 
         async def wrapper(req):
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._handle_request, req)
+            self._handle_request(req)
             res = orig_cb(req)
             if isinstance(res, types.CoroutineType):
                 res = await res
@@ -77,9 +76,7 @@ class ResourceManager:
             logger.info(f"Registering {ntype} {sysid} from agent {node.agentId}")
             jsobj = json.loads(payload.serialize())
 
-            # Save to Database — run_in_executor prevents blocking the event loop
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._node_db.upsert, {"systemSettings.ID": str(sysid)}, jsobj)
+            await self._async_node_db.upsert({"systemSettings.ID": str(sysid)}, jsobj)
             logger.info(f"Registering {ntype} {sysid} succeed.")
             self._is_topo_updated = True
         except Exception as e:

--- a/quantnet_controller/core/managers.py
+++ b/quantnet_controller/core/managers.py
@@ -54,7 +54,8 @@ class ResourceManager:
         """Capture all requests to the controller"""
 
         async def wrapper(req):
-            self._handle_request(req)
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._handle_request, req)
             res = orig_cb(req)
             if isinstance(res, types.CoroutineType):
                 res = await res
@@ -67,6 +68,8 @@ class ResourceManager:
         if node is None:
             raise ValueError("handle_register: invalid input parameter - node is None")
 
+        sysid = None
+        ntype = None
         try:
             payload = node.payload
             sysid = payload.systemSettings.ID

--- a/quantnet_controller/core/managers.py
+++ b/quantnet_controller/core/managers.py
@@ -2,6 +2,7 @@
 Resource Manager
 """
 
+import asyncio
 import json
 import logging
 import types
@@ -73,8 +74,9 @@ class ResourceManager:
             logger.info(f"Registering {ntype} {sysid} from agent {node.agentId}")
             jsobj = json.loads(payload.serialize())
 
-            # Save to Database
-            self._node_db.upsert({"systemSettings.ID": str(sysid)}, jsobj)
+            # Save to Database — run_in_executor prevents blocking the event loop
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._node_db.upsert, {"systemSettings.ID": str(sysid)}, jsobj)
             logger.info(f"Registering {ntype} {sysid} succeed.")
             self._is_topo_updated = True
         except Exception as e:

--- a/quantnet_controller/core/managers.py
+++ b/quantnet_controller/core/managers.py
@@ -188,13 +188,15 @@ class ResourceManager:
         self._topo = g
 
     def get_node_state(self, agentid):
-        handler = DB().handler(DBmodel.Monitor)
-        res = handler.find(filter={"rid": str(agentid), "eventType": EventType.AGENT_STATE}, limit=1, sort={"ts": -1})
+        # Query the capped MonitorState collection — only agentState events,
+        # natural order = insertion order, so $natural: -1 gives the latest first.
+        handler = DB().handler(DBmodel.MonitorState)
+        res = handler.find(filter={"rid": str(agentid)}, limit=1, sort=[("$natural", -1)])
         return res[0] if res else None
 
     def get_exp_results(self, exp_id):
         handler = DB().handler(DBmodel.Monitor)
-        return handler.find(filter={"exp_id": str(exp_id), "eventType": EventType.EXPERIMENT_RESULT})
+        return handler.find(filter={"value.exp_id": str(exp_id), "eventType": EventType.EXPERIMENT_RESULT})
 
     def get_topology(self, full: bool = False):
         if not self._topo or self._is_topo_updated or self._is_topo_full != full:

--- a/quantnet_controller/db/async_broker.py
+++ b/quantnet_controller/db/async_broker.py
@@ -1,0 +1,95 @@
+"""
+Async Broker — mirrors broker.py using AsyncCollection (pymongo native async).
+"""
+
+import os
+import abc
+from functools import wraps
+from quantnet_controller.utils.util import import_classes_from_package
+from quantnet_controller.db.nosql.collection.async_collection import AsyncCollection
+from quantnet_controller.db.broker import (
+    DATABASE_SECTION, BrokerType, check_database_type,
+)
+
+__ASYNC_BROKER = None
+__ASYNC_BROKER_CONFIG = None
+
+
+def init_async_broker_config(config):
+    global __ASYNC_BROKER_CONFIG
+    __ASYNC_BROKER_CONFIG = config
+
+
+class AsyncBroker(object, metaclass=abc.ABCMeta):
+    def _get_hndl(self, model):
+        return self.classes[model]() if self.classes.get(model) else self.default(model)
+
+    async def add(self, model, data, **kwargs):
+        return await self._get_hndl(model).add(data, **kwargs)
+
+    async def get(self, model, id, **kwargs):
+        return await self._get_hndl(model).get(id, **kwargs)
+
+    async def find(self, model, **kwargs):
+        return await self._get_hndl(model).find(**kwargs)
+
+    async def update(self, model, id, key, value, **kwargs):
+        return await self._get_hndl(model).update(id, key, value, **kwargs)
+
+    async def upsert(self, model, id, *args, **kwargs):
+        return await self._get_hndl(model).upsert(id, *args, **kwargs)
+
+    async def delete(self, model, id, **kwargs):
+        return await self._get_hndl(model).delete(id, **kwargs)
+
+    async def exist(self, model, id, **kwargs):
+        return await self._get_hndl(model).exist(id, **kwargs)
+
+    async def drop(self, model, **kwargs):
+        return await self._get_hndl(model).drop(**kwargs)
+
+    async def drop_database(self, model, **kwargs):
+        return await self._get_hndl(model).drop_database(**kwargs)
+
+
+class AsyncMongoBroker(AsyncBroker):
+    def __init__(self, config=None, **kwargs):
+        current_file_directory = os.path.dirname(os.path.abspath(__file__))
+        # Read collection config from sync classes — they are the single source of truth
+        # for _capped, _history, _size. No parallel async directory needed.
+        self._sync_classes = import_classes_from_package(f"{current_file_directory}/nosql/collection")
+
+    def _get_hndl(self, model):
+        """Build an AsyncCollection stamped with config from the matching sync class."""
+        sync_cls = self._sync_classes.get(model)
+        ac = AsyncCollection(model)
+        if sync_cls:
+            ac._capped = getattr(sync_cls, '_capped', False)
+            ac._history = getattr(sync_cls, '_history', False)
+            ac._size = getattr(sync_cls, '_size', None)
+        return ac
+
+
+def async_broker(func):
+    """Async version of the @broker decorator. Lazily initializes AsyncMongoBroker."""
+    @wraps(func)
+    async def wrapper(*args, broker=None, **kwargs):
+        global __ASYNC_BROKER
+        if __ASYNC_BROKER is None:
+            url = __ASYNC_BROKER_CONFIG.get(
+                DATABASE_SECTION, 'default',
+                default="mongodb://localhost",
+                check_config_table=False,
+            ) if __ASYNC_BROKER_CONFIG else "mongodb://localhost"
+            broker_type = check_database_type(url)
+            if broker_type == BrokerType.MONGO:
+                broker = AsyncMongoBroker(config=__ASYNC_BROKER_CONFIG)
+            else:
+                raise Exception(f"Async broker only supports MongoDB, got {url}")
+            __ASYNC_BROKER = broker
+        else:
+            broker = __ASYNC_BROKER
+
+        return await func(*args, broker=broker, **kwargs)
+
+    return wrapper

--- a/quantnet_controller/db/nosql/async_db.py
+++ b/quantnet_controller/db/nosql/async_db.py
@@ -1,0 +1,153 @@
+"""
+Async DB Layer — mirrors db.py using pymongo's native async API (pymongo >= 4.9).
+"""
+
+import time
+import logging
+import sys
+
+from bson.objectid import ObjectId
+from pymongo import AsyncMongoClient
+from quantnet_controller.common.utils import get_uri_path
+
+
+class AsyncDBLayer:
+    """
+    Async wrapper for MongoDB collections.
+
+    Same semantics as DBLayer but all I/O methods are async def.
+    """
+
+    def __init__(self, client, collection_name, capped=False, Id="id", timestamp="ts", *, history=False):
+        self.log = logging.getLogger(__name__)
+        self.Id = Id
+        self.timestamp = timestamp
+        self.history, self.capped = history, capped
+        self._collection_name = collection_name
+        self._client = client
+
+    @property
+    def collection(self):
+        """Returns a reference to the mongodb collection."""
+        return self._client[self._collection_name]
+
+    async def find_one(self, query={}, **kwargs):
+        self.log.debug(f"Find one for collection: [{self._collection_name}]")
+        fields = kwargs.pop("fields", {})
+        fields["_id"] = 0
+        result = await self.collection.find_one(query, projection=fields, **kwargs)
+        return result
+
+    async def count(self, query={}, **kwargs):
+        skip = kwargs.get("skip", 0)
+        if "limit" in kwargs:
+            return await self.collection.count_documents(query, skip=skip, limit=kwargs["limit"])
+        return await self.collection.count_documents(query, skip=skip)
+
+    async def find(self, query={}, **kwargs):
+        """Finds one or more elements in the collection."""
+        self.log.debug(f"Find for collection: [{self._collection_name}]")
+        fields = kwargs.pop("fields", {})
+        fields["_id"] = 0
+        cursor = self.collection.find(query, fields, **kwargs)
+        return await cursor.to_list()
+
+    def _insert_id(self, data):
+        if "_id" not in data and not self.capped:
+            res_id = data.get(self.Id, str(ObjectId()))
+            timestamp = data.get(self.timestamp, int(time.time() * 1e6))
+            data["_id"] = f"{res_id}:{timestamp}" if self.history else res_id
+
+    async def insert(self, data, summarize=True, **kwargs):
+        """Inserts data to the collection."""
+        self.log.debug(f"Insert for collection: [{self._collection_name}]")
+        data = [data] if not isinstance(data, list) else data
+        if not self.capped:
+            for item in data:
+                self._insert_id(item)
+
+        if self.history:
+            results = await self.collection.insert_many(data, **kwargs)
+        else:
+            results = []
+            for item in data:
+                rid = item.get(self.Id, str(ObjectId()))
+                results.append(await self.collection.replace_one({self.Id: rid}, item, upsert=True))
+        return results
+
+    async def upsert(self, query, data):
+        return await self.collection.replace_one(query, data, upsert=True)
+
+    async def update(self, query, data, replace=False, multi=True, **kwargs):
+        """Updates data found by query in the collection."""
+        self.log.debug(f"Update for Collection: [{self._collection_name}]")
+        if not replace:
+            data = {"$set": data}
+        if multi:
+            results = await self.collection.update_many(query, data)
+        else:
+            results = await self.collection.find_one_and_update(query, data, upsert=False, **kwargs)
+            for r in results:
+                if isinstance(r, dict) and not r.get("updatedExisting", True):
+                    raise LookupError("Resource ID does not exist")
+        return results
+
+    async def remove(self, query, callback=None, **kwargs):
+        self.log.debug(f"Remove for collection: [{self._collection_name}]")
+        results = await self.collection.delete_many(query)
+        return results
+
+    async def create_index(self, keys, **kwargs):
+        """Create an index on the collection."""
+        return await self.collection.create_index(keys, **kwargs)
+
+    async def drop(self, **kwargs):
+        await self.collection.drop()
+
+    async def drop_database(self, **kwargs):
+        await self._client.db.command("dropDatabase")
+
+
+class AsyncDBLoader:
+    def __init__(self, config=None, **kwargs):
+        self.log = logging.getLogger(__name__)
+        self._config = config
+        self._dbname = kwargs.get("dbname", "quantnet")
+        self._capped_collections = set()
+        self._db = self._init()
+
+    @property
+    def db(self):
+        return self._db
+
+    def _init(self):
+        """Initialize the async client. AsyncMongoClient constructor is sync;
+        actual connection happens lazily on first operation."""
+        try:
+            url = self._config.get('database', 'default',
+                                   default="mongodb://localhost",
+                                   check_config_table=False) if self._config else "mongodb://localhost"
+            path = get_uri_path(url)
+            self._dbname = path if path else self._dbname
+            self._conn = AsyncMongoClient(url)
+        except Exception as exp:
+            self.log.error(f"Failed to initialize async client - {exp}")
+            sys.exit()
+        self._db = self._conn[self._dbname]
+        return self._db
+
+    async def drop_database(self, **kwargs):
+        await self._conn.drop_database(self._dbname)
+
+    async def get_db_layer(self, collection_name, id_field_name, capped=False, history=False, size=None):
+        if not collection_name:
+            return None
+        if capped and collection_name not in self._capped_collections:
+            existing = await self.db.list_collection_names()
+            if collection_name not in existing:
+                cap_size = size or 10 * 1024 * 1024
+                await self.db.create_collection(collection_name, capped=True, size=cap_size)
+                self.log.info(f"Created capped collection '{collection_name}' (size={cap_size})")
+            self._capped_collections.add(collection_name)
+        db_layer = AsyncDBLayer(self.db, collection_name, capped, id_field_name, history=history)
+        return db_layer

--- a/quantnet_controller/db/nosql/collection/__init__.py
+++ b/quantnet_controller/db/nosql/collection/__init__.py
@@ -19,6 +19,9 @@ class Collection:
     # Otherwise, a new internal '_id' will be generated but
     # will not be exposed to user.
     _keyname = "_id"
+    _capped = False
+    _history = False
+    _size = None  # bytes; only used when _capped=True
 
     def __init__(self, model="default"):
         self._collection_name = model if model else "default"
@@ -32,7 +35,10 @@ class Collection:
             global _DATABASE
             if _DATABASE is None:
                 _DATABASE = DBLoader(config=_COLLECTION_CONFIG)
-            layer = _DATABASE.get_db_layer(self._collection_name, key)
+            layer = _DATABASE.get_db_layer(
+                self._collection_name, key,
+                capped=self._capped, history=self._history, size=self._size,
+            )
             return func(self, *args, **kwargs, layer=layer)
         return wrapper
 
@@ -41,11 +47,14 @@ class Collection:
         if not isinstance(data, dict):
             raise Exception(f"Type error: {data} is not dict")
         try:
-            docs = layer.insert(data)
-            if len(docs) == 1 and docs[0].upserted_id:
-                return data
-            else:
+            result = layer.insert(data)
+            # history=True path returns InsertManyResult; history=False returns list of UpdateResult
+            if isinstance(result, list):
+                if len(result) == 1 and result[0].upserted_id:
+                    return data
                 return None
+            # InsertManyResult — inserted successfully
+            return data if result.inserted_ids else None
         except Exception:
             raise
 
@@ -127,10 +136,18 @@ class Collection:
         return True if layer.find_one(filter) else False
 
     @layer
+    def count(self, layer=None, **kwargs):
+        q = kwargs.pop("filter", {})
+        return layer.count(q, **kwargs)
+
+    @layer
+    def create_index(self, keys, layer=None, **kwargs):
+        return layer.create_index(keys, **kwargs)
+
+    @layer
     def drop(self, layer=None, **kwargs):
         return layer.drop(**kwargs)
 
     @layer
     def drop_database(self, layer=None, **kwargs):
-        global _DATABASE
         _DATABASE.drop_database(**kwargs)

--- a/quantnet_controller/db/nosql/collection/async_collection.py
+++ b/quantnet_controller/db/nosql/collection/async_collection.py
@@ -1,0 +1,120 @@
+"""
+Async Collection — mirrors Collection using AsyncDBLayer (pymongo native async).
+"""
+
+from functools import wraps
+from quantnet_controller.db.nosql.async_db import AsyncDBLoader
+
+_ASYNC_DATABASE = None
+_ASYNC_COLLECTION_CONFIG = None
+
+
+def init_async_collection_config(config):
+    global _ASYNC_COLLECTION_CONFIG
+    _ASYNC_COLLECTION_CONFIG = config
+
+
+class AsyncCollection:
+    _keyname = "_id"
+    _capped = False
+    _history = False
+    _size = None
+
+    def __init__(self, model="default"):
+        self._collection_name = model if model else "default"
+
+    def async_layer(func):
+        """Decorator that lazily initializes the AsyncDBLoader and injects an AsyncDBLayer."""
+        @wraps(func)
+        async def wrapper(self, *args, **kwargs):
+            key = AsyncCollection._keyname
+            global _ASYNC_DATABASE
+            if _ASYNC_DATABASE is None:
+                _ASYNC_DATABASE = AsyncDBLoader(config=_ASYNC_COLLECTION_CONFIG)
+            layer = await _ASYNC_DATABASE.get_db_layer(
+                self._collection_name, key,
+                capped=self._capped, history=self._history, size=self._size,
+            )
+            return await func(self, *args, **kwargs, layer=layer)
+        return wrapper
+
+    @async_layer
+    async def add(self, data, layer=None, **kwargs):
+        if not isinstance(data, dict):
+            raise Exception(f"Type error: {data} is not dict")
+        result = await layer.insert(data)
+        if isinstance(result, list):
+            if len(result) == 1 and result[0].upserted_id:
+                return data
+            return None
+        # InsertManyResult
+        return data if result.inserted_ids else None
+
+    @async_layer
+    async def find(self, layer=None, **kwargs):
+        q = kwargs.pop("filter", {})
+        return await layer.find(q, **kwargs)
+
+    @async_layer
+    async def get(self, id, layer=None, **kwargs):
+        if isinstance(id, dict):
+            filter = id
+        elif isinstance(id, str):
+            filter = {self._keyname: id}
+        else:
+            raise Exception(f"{id} must be either dict or str")
+        return await layer.find_one(filter)
+
+    @async_layer
+    async def update(self, id, key, value, layer=None):
+        filter = {self._keyname: id} if not isinstance(id, dict) else id
+        result = await layer.update(filter, {key: value})
+        return True if result.modified_count else False
+
+    @async_layer
+    async def upsert(self, id, *args, layer=None, **kwargs):
+        def combine(*args):
+            combined_dict = {}
+            for d in args:
+                combined_dict.update(d)
+            return combined_dict
+
+        data = combine(*args) if args else {}
+        if not data:
+            return
+
+        filter = {self._keyname: id} if not isinstance(id, dict) else id
+
+        if await layer.find_one(filter):
+            ret = await layer.update(filter, data)
+            return True if ret.modified_count else False
+        else:
+            return await self.add(data)
+
+    @async_layer
+    async def delete(self, id, layer=None):
+        filter = {self._keyname: id} if not isinstance(id, dict) else id
+        result = await layer.remove(filter)
+        return result.deleted_count
+
+    @async_layer
+    async def exist(self, id, layer=None, **kwargs):
+        filter = {self._keyname: id} if not isinstance(id, dict) else id
+        return True if await layer.find_one(filter) else False
+
+    @async_layer
+    async def count(self, layer=None, **kwargs):
+        q = kwargs.pop("filter", {})
+        return await layer.count(q, **kwargs)
+
+    @async_layer
+    async def create_index(self, keys, layer=None, **kwargs):
+        return await layer.create_index(keys, **kwargs)
+
+    @async_layer
+    async def drop(self, layer=None, **kwargs):
+        await layer.drop(**kwargs)
+
+    @async_layer
+    async def drop_database(self, layer=None, **kwargs):
+        await _ASYNC_DATABASE.drop_database(**kwargs)

--- a/quantnet_controller/db/nosql/collection/monitor.py
+++ b/quantnet_controller/db/nosql/collection/monitor.py
@@ -1,0 +1,49 @@
+"""
+Monitor — regular collection for experiment/task result events.
+
+Stores experimentResult, agentTaskResult, agentTaskSchedulerPhase, and
+agentTaskSchedulerTask events. Indexes are created at server startup via
+ensure_indexes(). A TTL index on created_at expires documents after 30 days.
+"""
+
+import logging
+from pymongo import ASCENDING, DESCENDING
+
+from quantnet_controller.db.nosql.collection import Collection
+
+logger = logging.getLogger(__name__)
+
+_TTL_SECONDS = 30 * 24 * 3600  # 30 days
+
+
+class Monitor(Collection):
+    _indexes_created = False
+
+    def __init__(self):
+        self._collection_name = "Monitor"
+
+    def ensure_indexes(self):
+        """Create indexes if not already done for this process. Idempotent."""
+        if Monitor._indexes_created:
+            return
+        try:
+            # Covers get_exp_results and handle_get_tasks eventType-only prefix
+            self.create_index(
+                [("eventType", ASCENDING), ("value.exp_id", ASCENDING)],
+                name="idx_eventType_value_exp_id",
+            )
+            # Covers handle_get_tasks with agent_id filter
+            self.create_index(
+                [("eventType", ASCENDING), ("rid", ASCENDING)],
+                name="idx_eventType_rid",
+            )
+            # TTL — expires documents 30 days after created_at (datetime field)
+            self.create_index(
+                [("created_at", ASCENDING)],
+                expireAfterSeconds=_TTL_SECONDS,
+                name="idx_ttl_created_at",
+            )
+            Monitor._indexes_created = True
+            logger.info("Monitor collection indexes created")
+        except Exception as e:
+            logger.warning(f"Failed to create Monitor indexes: {e}")

--- a/quantnet_controller/db/nosql/collection/monitor_state.py
+++ b/quantnet_controller/db/nosql/collection/monitor_state.py
@@ -1,0 +1,17 @@
+"""
+MonitorState — capped collection for agent state events.
+
+Stores only agentState events. Old entries are automatically evicted when
+the collection reaches _size, keeping only the most recent history.
+"""
+
+from quantnet_controller.db.nosql.collection import Collection
+
+
+class MonitorState(Collection):
+    _capped = True
+    _history = True
+    _size = 10 * 1024 * 1024  # 10 MB
+
+    def __init__(self):
+        self._collection_name = "MonitorState"

--- a/quantnet_controller/db/nosql/db.py
+++ b/quantnet_controller/db/nosql/db.py
@@ -120,6 +120,7 @@ class DBLoader:
         self._host = kwargs.get("host")
         self._port = kwargs.get("port")
         self._dbname = kwargs.get("dbname", "quantnet")
+        self._capped_collections = set()
         self._db = self._init()
 
     @property
@@ -156,9 +157,11 @@ class DBLoader:
     def get_db_layer(self, collection_name, id_field_name, capped=False, history=False, size=None):
         if not collection_name:
             return None
-        if capped and collection_name not in self.db.list_collection_names():
-            cap_size = size or 10 * 1024 * 1024  # default 10 MB
-            self.db.create_collection(collection_name, capped=True, size=cap_size)
-            self.log.info(f"Created capped collection '{collection_name}' (size={cap_size})")
+        if capped and collection_name not in self._capped_collections:
+            if collection_name not in self.db.list_collection_names():
+                cap_size = size or 10 * 1024 * 1024  # default 10 MB
+                self.db.create_collection(collection_name, capped=True, size=cap_size)
+                self.log.info(f"Created capped collection '{collection_name}' (size={cap_size})")
+            self._capped_collections.add(collection_name)
         db_layer = DBLayer(self.db, collection_name, capped, id_field_name, history=history)
         return db_layer

--- a/quantnet_controller/db/nosql/db.py
+++ b/quantnet_controller/db/nosql/db.py
@@ -99,6 +99,10 @@ class DBLayer(object):
         results = self.collection.delete_many(query)
         return results
 
+    def create_index(self, keys, **kwargs):
+        """Create an index on the collection. Thin pass-through to pymongo."""
+        return self.collection.create_index(keys, **kwargs)
+
     def drop(self, **kwargs):
         self.collection.drop()
 
@@ -149,8 +153,12 @@ class DBLoader:
     def drop_database(self, **kwargs):
         self._conn.drop_database(self._dbname)
 
-    def get_db_layer(self, collection_name, id_field_name):
+    def get_db_layer(self, collection_name, id_field_name, capped=False, history=False, size=None):
         if not collection_name:
             return None
-        db_layer = DBLayer(self.db, collection_name, False, id_field_name)
+        if capped and collection_name not in self.db.list_collection_names():
+            cap_size = size or 10 * 1024 * 1024  # default 10 MB
+            self.db.create_collection(collection_name, capped=True, size=cap_size)
+            self.log.info(f"Created capped collection '{collection_name}' (size={cap_size})")
+        db_layer = DBLayer(self.db, collection_name, capped, id_field_name, history=history)
         return db_layer

--- a/quantnet_controller/plugins/monitoring/__init__.py
+++ b/quantnet_controller/plugins/monitoring/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 from quantnet_controller.common.plugin import MonitoringPlugin, PluginType
@@ -25,21 +26,21 @@ class Monitor(MonitoringPlugin):
         logger.debug(f"Received resource update: {request}")
         try:
             obj = monitor.MonitorEvent.from_json(request)
+            loop = asyncio.get_running_loop()
             if obj.eventType == EventType.AGENT_HEARTBEAT:
                 # Update last_seen timestamp on the node record
                 agent_id = obj.rid
                 now = time.time()
-                self._node_db.update(
-                    {"systemSettings.ID": str(agent_id)},
-                    "last_seen",
-                    now
+                await loop.run_in_executor(
+                    None, self._node_db.update,
+                    {"systemSettings.ID": str(agent_id)}, "last_seen", now
                 )
                 logger.debug(f"Updated last_seen for node {agent_id} to {now}")
             else:
-                self._db.add(obj.as_dict())
+                await loop.run_in_executor(None, self._db.add, obj.as_dict())
                 if obj.eventType == EventType.AGENT_STATE:
                     logger.info(f"{obj.rid} {obj.eventType} is updated : "
-                                f"{self._context.rm.get_node_state(obj.rid)}")
+                                f"{obj.as_dict()}")
                 elif obj.eventType == EventType.EXPERIMENT_RESULT:
                     logger.info(f"{obj.rid} {obj.eventType} is updated : {obj.value}")
                 elif obj.eventType == EventType.AGENT_TASK_RESULT:
@@ -59,10 +60,11 @@ class Monitor(MonitoringPlugin):
                 filter["rid"] = agent_id
             
             logger.info(f"Querying Monitor DB with filter: {filter}")
-            all_records = list(self._db.find())
+            loop = asyncio.get_running_loop()
+            all_records = await loop.run_in_executor(None, lambda: list(self._db.find()))
             logger.info(f"DEBUG: Total records in Monitor collection: {len(all_records)}")
-            
-            results = list(self._db.find(filter=filter))
+
+            results = await loop.run_in_executor(None, lambda: list(self._db.find(filter=filter)))
             logger.info(f"Found {len(results)} results for filter {filter}")
             tasks = []
             for res in results:

--- a/quantnet_controller/plugins/monitoring/__init__.py
+++ b/quantnet_controller/plugins/monitoring/__init__.py
@@ -1,11 +1,10 @@
-import asyncio
 import logging
 import time
 from datetime import datetime, timezone
 from quantnet_controller.common.plugin import MonitoringPlugin, PluginType
 from quantnet_mq.schema.models import monitor, Status, agentMonitorTaskResponse
 from quantnet_mq import Code, EventType
-from quantnet_controller.core import AbstractDatabase as DB, DBmodel
+from quantnet_controller.core import AsyncAbstractDatabase as DB, DBmodel
 
 logger = logging.getLogger(__name__)
 
@@ -28,24 +27,22 @@ class Monitor(MonitoringPlugin):
         logger.debug(f"Received resource update: {request}")
         try:
             obj = monitor.MonitorEvent.from_json(request)
-            loop = asyncio.get_running_loop()
             if obj.eventType == EventType.AGENT_HEARTBEAT:
                 # Update last_seen timestamp on the node record
                 agent_id = obj.rid
                 now = time.time()
-                await loop.run_in_executor(
-                    None, self._node_db.update,
+                await self._node_db.update(
                     {"systemSettings.ID": str(agent_id)}, "last_seen", now
                 )
                 logger.debug(f"Updated last_seen for node {agent_id} to {now}")
             elif obj.eventType == EventType.AGENT_STATE:
                 # Capped collection — append-only, old entries auto-evicted
-                await loop.run_in_executor(None, self._state_db.add, obj.as_dict())
+                await self._state_db.add(obj.as_dict())
                 logger.info(f"{obj.rid} {obj.eventType} is updated : {obj.as_dict()}")
             else:
                 doc = obj.as_dict()
                 doc["created_at"] = datetime.now(timezone.utc)
-                await loop.run_in_executor(None, self._db.add, doc)
+                await self._db.add(doc)
                 if obj.eventType == EventType.EXPERIMENT_RESULT:
                     logger.info(f"{obj.rid} {obj.eventType} is updated : {obj.value}")
                 elif obj.eventType == EventType.AGENT_TASK_RESULT:
@@ -65,8 +62,7 @@ class Monitor(MonitoringPlugin):
                 filter["rid"] = agent_id
 
             logger.info(f"Querying Monitor DB with filter: {filter}")
-            loop = asyncio.get_running_loop()
-            results = await loop.run_in_executor(None, lambda: list(self._db.find(filter=filter)))
+            results = await self._db.find(filter=filter)
             logger.info(f"Found {len(results)} results for filter {filter}")
             tasks = []
             for res in results:

--- a/quantnet_controller/plugins/monitoring/__init__.py
+++ b/quantnet_controller/plugins/monitoring/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from datetime import datetime, timezone
 from quantnet_controller.common.plugin import MonitoringPlugin, PluginType
 from quantnet_mq.schema.models import monitor, Status, agentMonitorTaskResponse
 from quantnet_mq import Code, EventType
@@ -13,6 +14,7 @@ class Monitor(MonitoringPlugin):
     def __init__(self, context):
         super().__init__("monitor", PluginType.MONITORING, context)
         self._db = DB().handler(DBmodel.Monitor)
+        self._state_db = DB().handler(DBmodel.MonitorState)
         self._node_db = DB().handler(DBmodel.Node)
         logger.info(f"Monitor plugin initialized with DB handler: {self._db}")
         self._msg_commands = [
@@ -36,12 +38,15 @@ class Monitor(MonitoringPlugin):
                     {"systemSettings.ID": str(agent_id)}, "last_seen", now
                 )
                 logger.debug(f"Updated last_seen for node {agent_id} to {now}")
+            elif obj.eventType == EventType.AGENT_STATE:
+                # Capped collection — append-only, old entries auto-evicted
+                await loop.run_in_executor(None, self._state_db.add, obj.as_dict())
+                logger.info(f"{obj.rid} {obj.eventType} is updated : {obj.as_dict()}")
             else:
-                await loop.run_in_executor(None, self._db.add, obj.as_dict())
-                if obj.eventType == EventType.AGENT_STATE:
-                    logger.info(f"{obj.rid} {obj.eventType} is updated : "
-                                f"{obj.as_dict()}")
-                elif obj.eventType == EventType.EXPERIMENT_RESULT:
+                doc = obj.as_dict()
+                doc["created_at"] = datetime.now(timezone.utc)
+                await loop.run_in_executor(None, self._db.add, doc)
+                if obj.eventType == EventType.EXPERIMENT_RESULT:
                     logger.info(f"{obj.rid} {obj.eventType} is updated : {obj.value}")
                 elif obj.eventType == EventType.AGENT_TASK_RESULT:
                     logger.info(f"{obj.rid} {obj.eventType} is updated : {obj.value}")
@@ -54,16 +59,13 @@ class Monitor(MonitoringPlugin):
             agent_id = request.payload.agent_id
             if agent_id:
                 agent_id = str(agent_id).strip()
-            
+
             filter = {"eventType": EventType.AGENT_TASK_RESULT}
             if agent_id:
                 filter["rid"] = agent_id
-            
+
             logger.info(f"Querying Monitor DB with filter: {filter}")
             loop = asyncio.get_running_loop()
-            all_records = await loop.run_in_executor(None, lambda: list(self._db.find()))
-            logger.info(f"DEBUG: Total records in Monitor collection: {len(all_records)}")
-
             results = await loop.run_in_executor(None, lambda: list(self._db.find(filter=filter)))
             logger.info(f"Found {len(results)} results for filter {filter}")
             tasks = []
@@ -79,10 +81,15 @@ class Monitor(MonitoringPlugin):
                     "agentIds": [res["rid"]],
                     "expName": res["value"].get("name"),
                 })
-            return agentMonitorTaskResponse(status=Status(code=Code.OK.value, value=Code.OK.name), tasks=tasks)
+            return agentMonitorTaskResponse(
+                status=Status(code=Code.OK.value, value=Code.OK.name), tasks=tasks
+            )
         except Exception as e:
             logger.error(f"Failed to get tasks: {e}")
-            return agentMonitorTaskResponse(status=Status(code=Code.INTERNAL.value, value=Code.INTERNAL.name, message=str(e)), tasks=[])
+            return agentMonitorTaskResponse(
+                status=Status(code=Code.INTERNAL.value, value=Code.INTERNAL.name, message=str(e)),
+                tasks=[],
+            )
 
     def initialize(self):
         pass
@@ -94,4 +101,6 @@ class Monitor(MonitoringPlugin):
         pass
 
     def start(self):
+        from quantnet_controller.db.nosql.collection.monitor import Monitor as MonitorCollection
+        MonitorCollection().ensure_indexes()
         logger.info("Monitor started and listening on /monitor topic")

--- a/quantnet_controller/plugins/protocols/simulation/__init__.py
+++ b/quantnet_controller/plugins/protocols/simulation/__init__.py
@@ -44,7 +44,7 @@ class SimulationPrtocol(ProtocolPlugin):
                 "id": simid,
                 "name": request.payload.parameters.get("name"),
                 "src": request.payload.parameters.get("src"),
-                "params": request.payload.parameters,
+                "exp_params": request.payload.parameters,
             }
 
             rc = await self.ctx.request_middleware.schedule(parameters, "Simulation")

--- a/regression_tests/scripts/check_container.sh
+++ b/regression_tests/scripts/check_container.sh
@@ -16,6 +16,11 @@ for CONTAINER in "${CONTAINERS[@]}"; do
     # Get container exit code
     EXITED=$(docker inspect -f '{{.State.ExitCode}}' "$CONTAINER_ID")
 
+    if [ "$EXITED" != "0" ]; then
+        echo "❌ Container $CONTAINER exited with code $EXITED"
+        HAS_ERROR=1
+    fi
+
     # Get container logs
     LOGS=$(docker compose -f regression_tests/docker-compose.yml logs "$CONTAINER")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ SQLAlchemy==1.4.31
 uvloop==0.21.0
 networkx==3.4.2
 aioschedule==0.5.2
-pymongo==4.6.3
+pymongo>=4.9,<5
 bitarray==3.0.0
 requests==2.32.4
 quantnet-mq


### PR DESCRIPTION
## Summary

This branch resolves three categories of problems discovered during review: non-blocking I/O, split monitoring storage, and a handful of correctness bugs.

### Non-blocking database I/O

Blocking PyMongo calls were running directly on the asyncio event loop in two places, causing head-of-line blocking under any concurrent load:

- **`handle_resource_update`** (monitoring plugin) — heartbeat updates and state/result inserts are now dispatched via `loop.run_in_executor`
- **`request_cb_wrapper`** (resource manager) — request recording (`_handle_request`) is now offloaded to an executor, consistent with the pattern already used in `handle_register`

### Monitor / MonitorState collection split

Agent state events and experiment/task result events have different retention needs. Previously they shared one collection with no TTL.

- **`Monitor`** — new collection class for result events (`EXPERIMENT_RESULT`, `AGENT_TASK_RESULT`, etc.). Adds a 30-day TTL index on `created_at`, plus compound indexes covering the two common query shapes (`eventType + value.exp_id`, `eventType + rid`). Indexes are created once at server startup via `ensure_indexes()` called from `Monitor.start()`.
- **`MonitorState`** — new capped collection (10 MB) for `AGENT_STATE` events only. Capped collections provide O(1) inserts and automatic eviction of old entries; `get_node_state` queries it with `$natural: -1` to get the latest state in O(1).
- **`DBmodel.MonitorState`** added to the enum so handlers can be constructed via `DB().handler(DBmodel.MonitorState)`.
- **`Collection`** base class gains `_capped`, `_history`, and `_size` class attributes, wired through to `get_db_layer`. `count` and `create_index` are also exposed. Capped-collection existence is now cached in `DBLoader._capped_collections` so `list_collection_names()` is only called once per collection name instead of on every operation.

### Correctness fixes

- **Simulation plugin** — `parameters["params"]` renamed to `parameters["exp_params"]` to match the key `start_experiment` reads. This was the only caller that had not been updated when the key was renamed; simulations were silently running with no parameters.
- **`match_agent_to_exp`** — `_validate_agent_requirements` now returns `reachable_nodes` (the stale-filtered list). The caller uses it as the input to the matching loop instead of the original unfiltered list, so stale nodes cannot be assigned to experiment slots.
- **`handle_register`** — `sysid` and `ntype` are initialised to `None` before the `try` block, preventing a secondary `UnboundLocalError` in the `except` log line when the exception fires before those variables are assigned.
- **`check_container.sh`** — restored the `if [ "$EXITED" != "0" ]` guard that was accidentally dropped. Without it a silently crashed container (signal kill, no log output) would not set `HAS_ERROR` and CI would pass.

